### PR TITLE
fix: race in username quota counter causing record/count inconsistency

### DIFF
--- a/changes/ee/fix-17575.en.md
+++ b/changes/ee/fix-17575.en.md
@@ -1,0 +1,1 @@
+Fixed a race condition in the emqx_username_quota plugin that could cause the per-username session counter to become inconsistent with the actual number of tracked client records. The counter could be decremented past zero and then be deleted while a concurrent session registration incremented it, losing the increment permanently.

--- a/plugins/emqx_username_quota/changelog.md
+++ b/plugins/emqx_username_quota/changelog.md
@@ -44,3 +44,12 @@
 - Moved quota exceeded warning logs into the stats worker and throttled them per username.
   A warning is emitted for the first rejection, when the previous warning is older than 1 minute,
   or on every 100th rejection for that username.
+
+## 1.2.1
+
+- Fixed a race condition that could cause per-username session counter to become inconsistent
+  with the tracked client records. The counter could be lost when a concurrent session registration
+  incremented it while a cleanup process deleted the counter key after decrementing it to zero.
+- Swapped the order of record deletion and counter decrement in cleanup paths so that
+  a crash between the two operations leaves the counter slightly higher (safe direction)
+  rather than lower.

--- a/plugins/emqx_username_quota/src/emqx_username_quota_state.erl
+++ b/plugins/emqx_username_quota/src/emqx_username_quota_state.erl
@@ -81,8 +81,8 @@ del(Pid) ->
         Monitors ->
             lists:foreach(
                 fun(?MONITOR(_, Username, ClientId)) ->
-                    dec_counter(Username),
                     ok = mria:dirty_delete(?RECORD_TAB, ?RECORD_KEY(Username, ClientId, Pid)),
+                    dec_counter(Username),
                     evict_ccache(Username)
                 end,
                 Monitors
@@ -332,8 +332,8 @@ evict_ccache(Username) ->
     ok.
 
 delete_client_records(Username, ClientId, ?RECORD_KEY(Username, ClientId, Pid) = Key) ->
-    dec_counter(Username),
     ok = mria:dirty_delete(?RECORD_TAB, Key),
+    dec_counter(Username),
     _ = ets:delete_object(?MONITOR_TAB, ?MONITOR(Pid, Username, ClientId)),
     evict_ccache(Username),
     delete_client_records(Username, ClientId, ets:next(?RECORD_TAB, Key));
@@ -349,14 +349,8 @@ do_clear_for_node(Node) ->
     ok.
 
 dec_counter(Username) ->
-    Key = ?COUNTER_KEY(Username, node()),
-    case mria:dirty_update_counter(?COUNTER_TAB, Key, -1) of
-        NewCount when is_integer(NewCount), NewCount =< 0 ->
-            _ = mria:dirty_delete(?COUNTER_TAB, Key),
-            ok;
-        _ ->
-            ok
-    end.
+    _ = mria:dirty_update_counter(?COUNTER_TAB, ?COUNTER_KEY(Username, node()), -1),
+    ok.
 
 monitor_exists(Pid, Username, ClientId) ->
     lists:any(

--- a/plugins/emqx_username_quota/test/emqx_username_quota_SUITE.erl
+++ b/plugins/emqx_username_quota/test/emqx_username_quota_SUITE.erl
@@ -8,6 +8,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include("emqx_username_quota.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -772,3 +773,65 @@ await_list_usernames(QueryString, N) ->
             timer:sleep(25),
             await_list_usernames(QueryString, N - 1)
     end.
+
+%%--------------------------------------------------------------------
+%% Counter race fix tests
+%%--------------------------------------------------------------------
+
+t_counter_consistency_concurrent(_Config) ->
+    User = <<"race-user">>,
+    N = 40,
+    Parent = self(),
+    Procs = [
+        spawn_link(fun() ->
+            ClientId = list_to_binary(io_lib:format("rc~p", [I])),
+            emqx_username_quota_state:add(User, ClientId, self()),
+            timer:sleep(rand:uniform(5)),
+            emqx_username_quota_state:del(self()),
+            Parent ! {done, I}
+        end)
+     || I <- lists:seq(1, N)
+    ],
+    lists:foreach(fun(_) -> receive {done, _} -> ok end end, lists:seq(1, N)),
+    timer:sleep(100),
+    RecCount = ets:info(?RECORD_TAB, size),
+    CtrSum = emqx_username_quota:session_count(User),
+    CtrEntries = ets:tab2list(?COUNTER_TAB),
+    ?assertEqual(0, RecCount),
+    ?assertEqual(0, CtrSum),
+    ?assertEqual(
+        [{?COUNTER_TAB, {User, node()}, 0}],
+        CtrEntries
+    ).
+
+t_counter_not_deleted_when_zero(_Config) ->
+    User = <<"zero-user">>,
+    emqx_username_quota:register_session(User, <<"c1">>),
+    ?assertEqual(1, emqx_username_quota:session_count(User)),
+    %% Delete all sessions — counter should stay at 0, not disappear
+    emqx_username_quota:unregister_session(User, <<"c1">>),
+    ?assertEqual(0, emqx_username_quota:session_count(User)),
+    %% Verify counter entry still exists (key not deleted)
+    CtrEntries = ets:tab2list(?COUNTER_TAB),
+    ?assertMatch(
+        [{?COUNTER_TAB, {User, _}, 0}],
+        CtrEntries
+    ),
+    %% Re-register should bring counter back to positive
+    emqx_username_quota:register_session(User, <<"c1">>),
+    ?assertEqual(1, emqx_username_quota:session_count(User)).
+
+t_double_unregister_counter_safety(_Config) ->
+    User = <<"doubler">>,
+    emqx_username_quota:register_session(User, <<"c1">>),
+    emqx_username_quota:register_session(User, <<"c2">>),
+    ?assertEqual(2, emqx_username_quota:session_count(User)),
+    %% Unregister the same client twice — counter should not go below 0 visually
+    emqx_username_quota:unregister_session(User, <<"c1">>),
+    emqx_username_quota:unregister_session(User, <<"c1">>),
+    ?assertEqual(1, emqx_username_quota:session_count(User)),
+    emqx_username_quota:unregister_session(User, <<"c2">>),
+    ?assertEqual(0, emqx_username_quota:session_count(User)),
+    %% After all deletions, re-register and verify counter recovers
+    emqx_username_quota:register_session(User, <<"c3">>),
+    ?assertEqual(1, emqx_username_quota:session_count(User)).


### PR DESCRIPTION
Release version: 6.0.3

## Summary

Fixed a race condition in `emqx_username_quota_state:dec_counter/1` where the per-username session counter could be permanently lost.

**Root cause**: `dec_counter/1` does `mria:dirty_update_counter(-1)` and, when the result reaches ≤0, deletes the counter key via `mria:dirty_delete`. Between the update and the delete, a concurrent `add` (session registration) can increment the same counter. The subsequent `dirty_delete` then destroys the counter value, losing the increment permanently. This causes `RECORD_TAB` (actual sessions) to have more entries than `COUNTER_TAB` (tracked counts), making the quota enforcement inaccurate.

**Fix** (3 changes in `emqx_username_quota_state.erl`):

1. **`dec_counter/1`**: Removed `dirty_delete`. Counter keys now stay in the table at 0 or negative values. The reader (`sum_username_counters`) already filters `Count > 0`, so ≤0 values are treated the same as missing keys.

2. **`del/1`**: Swapped order — delete `RECORD_TAB` record first, then call `dec_counter`. If a crash occurs between them, the record is already gone and the counter is slightly higher (safe direction: rejects a few more connections, not fewer).

3. **`delete_client_records/2`**: Same order swap.

**Tests added** (`emqx_username_quota_SUITE.erl`):
- `t_counter_consistency_concurrent` — 40 concurrent add/del with same username, verify counter matches records
- `t_counter_not_deleted_when_zero` — verify counter entry persists at 0 after all sessions removed
- `t_double_unregister_counter_safety` — verify repeated unregister does not break counters

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log added to `changes/ee/fix-17575.en.md`
- [x] Plugin changelog updated